### PR TITLE
Fix Ruby 2.7 issues

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,4 +59,4 @@ DEPENDENCIES
   roda
 
 BUNDLED WITH
-   1.16.1
+   2.2.5

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:bullseye-slim
 
 LABEL Author="kse@clearhaus.com" \
       Maintainer="Clearhaus"


### PR DESCRIPTION
Fixes two issues:

```
dry-core-0.8.1 requires ruby version >= 2.7.0, which is incompatible with the
current version, ruby 2.3.3p222
The command '/bin/sh -c apt-get update &&     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends         ruby bundler ruby-dev make gcc libc6-dev libssl-dev &&     bundle install --without test &&     DEBIAN_FRONTEND=noninteractive apt-get --purge remove -y         ruby-dev make gcc libc6-dev libssl-dev &&     DEBIAN_FRONTEND=noninteractive apt-get --purge autoremove -y &&     apt-get clean &&     rm -rf /var/lib/apt/lists/*' returned a non-zero code: 5
```

```
/usr/lib/ruby/vendor_ruby/rubygems.rb:281:in `find_spec_for_exe': Could not find 'bundler' (1.16.1) required by your /opt/applepaymerchant/Gemfile.lock. (Gem::GemNotFoundException)
To update to the latest version installed on your system, run `bundle update --bundler`.
To install the missing version, run `gem install bundler:1.16.1`
        from /usr/lib/ruby/vendor_ruby/rubygems.rb:300:in `activate_bin_path'
        from /usr/bin/bundle:23:in `<main>'
```

I have tested successfully towards production with the newly-built Docker image :heavy_check_mark: 