### PR TITLE
Add payment_processing.pem to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 merchant_identity.pem
 merchant_identity.key
+payment_processing.pem
 payment_processing.key
 config.json


### PR DESCRIPTION
I'm not entirely sure the file is necessary, however, it is mounted in:

```
$ egrep '\.(pem|key)$' docker-compose.yml 
      - ./merchant_identity.pem:/opt/applepaymerchant/merchant_identity.pem
      - ./merchant_identity.key:/opt/applepaymerchant/merchant_identity.key
      - ./payment_processing.pem:/opt/applepaymerchant/payment_processing.pem
      - ./payment_processing.key:/opt/applepaymerchant/payment_processing.key
```